### PR TITLE
Change URLs from tasteless.se to tasteless.eu

### DIFF
--- a/9447-ctf-2014/bashful/README.md
+++ b/9447-ctf-2014/bashful/README.md
@@ -96,5 +96,5 @@ $ cat token
 ## Other write-ups and resources
 
 * <https://github.com/hypnosec/writeups/blob/master/2014/9447-ctf/web/bashful.md>
-* <http://tasteless.se/2014/12/9447-security-society-ctf-2014-bashful-and-coffee-writeup/>
+* <http://tasteless.eu/2014/12/9447-security-society-ctf-2014-bashful-and-coffee-writeup/>
 * <https://ucs.fbi.h-da.de/writeup-9447-bashful/>

--- a/9447-ctf-2014/coffee/README.md
+++ b/9447-ctf-2014/coffee/README.md
@@ -15,4 +15,4 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/12/9447-security-society-ctf-2014-bashful-and-coffee-writeup/>
+* <http://tasteless.eu/2014/12/9447-security-society-ctf-2014-bashful-and-coffee-writeup/>

--- a/9447-ctf-2014/future/README.md
+++ b/9447-ctf-2014/future/README.md
@@ -21,6 +21,6 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/12/9447-security-society-ctf-2014-future-and-shmap-writeup/>
+* <http://tasteless.eu/2014/12/9447-security-society-ctf-2014-future-and-shmap-writeup/>
 * [Solution by @auscompgeek](https://gist.github.com/auscompgeek/a4390fb82a31ce69256b)
 * <http://blog.dul.ac/2014/12/9447CTF14/>

--- a/9447-ctf-2014/nosql/README.md
+++ b/9447-ctf-2014/nosql/README.md
@@ -18,5 +18,5 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/12/9447-ctf-2014-nosql/>
+* <http://tasteless.eu/2014/12/9447-ctf-2014-nosql/>
 * <http://blog.dul.ac/2014/12/9447CTF14/>

--- a/9447-ctf-2014/ramble/README.md
+++ b/9447-ctf-2014/ramble/README.md
@@ -90,7 +90,7 @@ Below are some possible ways to successfully exploit this challenge.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/12/9447-security-society-ctf-2014-ramble-writeup/>
+* <http://tasteless.eu/2014/12/9447-security-society-ctf-2014-ramble-writeup/>
 * [Exploit by Ymgve that leaks `/flag` piece by piece](https://gist.github.com/anonymous/fa48e7657ddf9d4f9d6d)
 * [Exploit by HoLyVieR using a timing attack + blind Shellshock injection](https://gist.github.com/jghkdgha/0a40941cdb072bfe269f)
 * [Exploit by cyberguru - execute command with one query](http://pastebin.com/nGGTNt6K)

--- a/9447-ctf-2014/shmap/README.md
+++ b/9447-ctf-2014/shmap/README.md
@@ -13,6 +13,6 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/12/9447-security-society-ctf-2014-future-and-shmap-writeup/>
+* <http://tasteless.eu/2014/12/9447-security-society-ctf-2014-future-and-shmap-writeup/>
 * <https://maltekraus.de/blog/ctf/english/2014/12/01/9447-ctf-shmap-writeup.html>
 * <http://blog.dul.ac/2014/12/9447CTF14/>

--- a/asis-ctf-finals-2014/a-familiar-system/README.md
+++ b/asis-ctf-finals-2014/a-familiar-system/README.md
@@ -145,5 +145,5 @@ Hence the flag is `ASIS_e4e6417b4baebb748da67e33f6e091d5`.
 
 ## Other write-ups and resources
 
-* Write-up by [tasteless](http://tasteless.se/2014/10/asis-ctf-finals-2014-a-familiar-system/)
+* Write-up by [tasteless](http://tasteless.eu/2014/10/asis-ctf-finals-2014-a-familiar-system/)
 * <https://beagleharrier.wordpress.com/2014/10/13/asis-ctf-finals-2014a-familiar-system-writeup/>

--- a/asis-ctf-finals-2014/numdroid/README.md
+++ b/asis-ctf-finals-2014/numdroid/README.md
@@ -397,4 +397,4 @@ That was a lot more fun than just running the Java code on my computer ;).
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/10/asis-ctf-finals-2014-numdroid/>
+* <http://tasteless.eu/2014/10/asis-ctf-finals-2014-numdroid/>

--- a/asis-ctf-finals-2014/satellite/README.md
+++ b/asis-ctf-finals-2014/satellite/README.md
@@ -35,6 +35,6 @@ Using [the `solve.py` script](solve.py), we solve all the SAT formulas and get t
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/10/asis-ctf-finals-2014-sattelite-ppc-200/>
+* <http://tasteless.eu/2014/10/asis-ctf-finals-2014-sattelite-ppc-200/>
 * <https://ctfcrew.org/writeup/81>
 * <http://bruce30262.logdown.com/posts/237394-asis-ctf-finals-2014-satellite>

--- a/asis-ctf-finals-2014/ultra-secure/README.md
+++ b/asis-ctf-finals-2014/ultra-secure/README.md
@@ -128,7 +128,7 @@ The flag is `ASIS_85c9febd4c15950ab1f19a6bd7a94f85`.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/10/asis-ctf-finals-2014-ultra-secure-crypto-400/>
+* <http://tasteless.eu/2014/10/asis-ctf-finals-2014-ultra-secure-crypto-400/>
 * <http://bt3gl.github.io/on-paillier-binary-search-and-the-asis-ctf-2014.html>
 * <http://blog.dragonsector.pl/2014/10/asis-ctf-finals-2014-ultra-secure.html>
 * [Exploit written in Python](http://pastebin.com/LsMRp71Y)

--- a/asis-ctf-finals-2014/voting/README.md
+++ b/asis-ctf-finals-2014/voting/README.md
@@ -61,4 +61,4 @@ Putting these pieces together results in `ASIS_1dc337d61dac5cb910eb5b8c17c52fef1
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/10/asis-ctf-finals-2014-voting/>
+* <http://tasteless.eu/2014/10/asis-ctf-finals-2014-voting/>

--- a/asis-ctf-quals-2014/forensic/README.md
+++ b/asis-ctf-quals-2014/forensic/README.md
@@ -52,6 +52,6 @@ This is a pcap file. Let’s open it in Wireshark and fire up a packet search fo
 ## Other write-ups and resources
 
 * <http://blog.squareroots.de/en/2014/05/asis-ctf-2014-forensic/>
-* <http://tasteless.se/2014/05/asis2014-forensic-150-forensic/>
+* <http://tasteless.eu/2014/05/asis2014-forensic-150-forensic/>
 * <http://blog.dul.ac/2014/05/ASISCTF14/>
 * <http://singularityctf.blogspot.de/2014/05/asis-ctf-quals-2014-writeup-forensic.html>

--- a/asis-ctf-quals-2014/hidden-flag/README.md
+++ b/asis-ctf-quals-2014/hidden-flag/README.md
@@ -88,7 +88,7 @@ The flag is `ASIS_b6be244608c27c2e869cb56167b649b1`.
 * <http://nickthefrost.com/2014/05/10/asis-ctf-quals-2014-hidden-flag/>
 * <http://www.incertia.net/blog/asis-2014-quals-hidden-flag/>
 * <http://blogs.univ-poitiers.fr/e-laize/2014/05/11/asis-2014-hiddenflag/>
-* <http://tasteless.se/2014/05/asis-ctf-quals-2014-hidden-flag-writeup/>
+* <http://tasteless.eu/2014/05/asis-ctf-quals-2014-hidden-flag-writeup/>
 * <http://quangntenemy.blogspot.de/2014/05/asis-ctf-quals-2014.html>
 * [Persian](http://xploit.ir/asis-2014-quals-%D9%BE%D8%B1%DA%86%D9%85-%D9%85%D8%AE%D9%81%DB%8C/)
 * <http://singularityctf.blogspot.de/2014/05/first-of-all-lets-check-headersdata.html>

--- a/asis-ctf-quals-2014/prying-ears/README.md
+++ b/asis-ctf-quals-2014/prying-ears/README.md
@@ -60,5 +60,5 @@ The PNG file contained the flag.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/05/asis2014-forensics-175-prying-ears/>
+* <http://tasteless.eu/2014/05/asis2014-forensics-175-prying-ears/>
 * <http://blog.dul.ac/2014/05/ASISCTF14/>

--- a/asis-ctf-quals-2014/spy-paper/README.md
+++ b/asis-ctf-quals-2014/spy-paper/README.md
@@ -14,5 +14,5 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/05/asis2014-stego-100-spy-paper/>
+* <http://tasteless.eu/2014/05/asis2014-stego-100-spy-paper/>
 * <http://quangntenemy.blogspot.de/2014/05/asis-ctf-quals-2014.html>

--- a/csaw-ctf-2014/hashes/README.md
+++ b/csaw-ctf-2014/hashes/README.md
@@ -47,5 +47,5 @@ The flag is `these_browser_bots_are_annoying`.
 ## Other write-ups and resources
 
 * <http://zoczus.blogspot.com/2014/09/csaw-ctf-web300-writeup.html>
-* <http://tasteless.se/2014/09/csaw-2014-quals-hashes-web300/>
+* <http://tasteless.eu/2014/09/csaw-2014-quals-hashes-web300/>
 * <http://blog.squareroots.de/en/2014/09/csaw14-hashes/>

--- a/csaw-ctf-2014/ish/README.md
+++ b/csaw-ctf-2014/ish/README.md
@@ -27,7 +27,7 @@ The flag is `AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHHIIIIJJJJKKKKLLLLMMMMOOOOXX`.
 ## Other write-ups and resources
 
 * <http://choppers.pw/posts/2014/09/21/csaw-quals-2014-ish/>
-* <http://tasteless.se/2014/09/csaw-2014-quals-ish-exploitation-300/>
+* <http://tasteless.eu/2014/09/csaw-2014-quals-ish-exploitation-300/>
 * [Exploit written in Python](https://gist.github.com/zachriggle/3670a74f7f6fd74fdaa5)
 * <http://rce4fun.blogspot.de/2014/09/csaw-ctf-2014-ish-exploitation-300.html>
 * <https://ctfcrew.org/writeup/78>

--- a/csaw-ctf-2014/s3/README.md
+++ b/csaw-ctf-2014/s3/README.md
@@ -21,7 +21,7 @@ The flag is `SimplyStupidStorage`.
 ## Other write-ups and resources
 
 * <http://choppers.pw/posts/2014/09/21/csaw-quals-2014-s3/>
-* <http://tasteless.se/2014/09/s3-writeup-csaw-2014-exploiting-300/>
+* <http://tasteless.eu/2014/09/s3-writeup-csaw-2014-exploiting-300/>
 * <http://v0ids3curity.blogspot.in/2014/09/csaw-ctf-quals-2014-s3-exploitation-300.html>
 * <https://ctfcrew.org/writeup/77>
 * <http://barrebas.github.io/blog/2014/09/25/CSAW-s3/>

--- a/csaw-ctf-2014/wololo/README.md
+++ b/csaw-ctf-2014/wololo/README.md
@@ -83,5 +83,5 @@ The challenge server says:  Sorry, your file did not pass all the checks.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/09/csaw-2014-quals-wololo-rev300/>
+* <http://tasteless.eu/2014/09/csaw-2014-quals-wololo-rev300/>
 * [Exploit written in Python by @ebeip90](https://gist.github.com/ebeip90/d167b9a52cb55fbffeb2#file-wololo-py)

--- a/csaw-ctf-2014/xorcise/README.md
+++ b/csaw-ctf-2014/xorcise/README.md
@@ -96,6 +96,6 @@ Remark: the problem we encountered when directly calling `system(cmd)` was that 
 
 * [Mirror of the above write-up by Mathy](http://www.mathyvanhoef.com/2014/09/csaw-2014-xorcise-challenge.html)
 * [Write-up by ekse](http://solution-36.blogspot.com/2014/09/csaw-2014-exploit-500-writeup-xorcise.html)
-* [Write-up by tasteless](http://tasteless.se/2014/09/xorcise-csaw-2014-exploiting-500/)
+* [Write-up by tasteless](http://tasteless.eu/2014/09/xorcise-csaw-2014-exploiting-500/)
 * [Excellent PoC by Henry Sanchez](https://gist.github.com/g05u/9e1ae04ad1252f709bb7)
 * <https://ctfcrew.org/writeup/69>

--- a/ghost-in-the-shellcode-2014/a-boaring-quest/README.md
+++ b/ghost-in-the-shellcode-2014/a-boaring-quest/README.md
@@ -14,6 +14,6 @@ The flag is `ZombieProcessesWillEatYourBrains`.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/01/gits-2014-a-boaring-quest-pwn-adventure-150/>
+* <http://tasteless.eu/2014/01/gits-2014-a-boaring-quest-pwn-adventure-150/>
 * <http://quangntenemy.blogspot.de/2014/01/ghost-in-shellcode-2014.html>
 * <http://balidani.blogspot.de/2014/01/ghost-in-shellcode-2014-pwn-adventure-2.html>

--- a/ghost-in-the-shellcode-2014/ad-subtract/README.md
+++ b/ghost-in-the-shellcode-2014/ad-subtract/README.md
@@ -22,4 +22,4 @@ After restarting the game, the ads are now transparent/invisible. This reveals t
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/01/gits-2014-ad-substract-pwn-adventure-75>
+* <http://tasteless.eu/2014/01/gits-2014-ad-substract-pwn-adventure-75>

--- a/ghost-in-the-shellcode-2014/lugkist/README.md
+++ b/ghost-in-the-shellcode-2014/lugkist/README.md
@@ -30,6 +30,6 @@ The flag is `Power overwhelming? Back in my day cheats did not have spaces.`.
 * <http://blog.zachorr.com/lugkist/>
 * <http://commandlinewani.blogspot.com/2014/01/ghostintheshellcode-write-up-lugkist.html>
 * <http://delogrand.blogspot.com/2014/01/ghost-in-shellcode-2014-trivia.html>
-* <http://tasteless.se/2014/01/gits-2014-lugkist-trivia-150>
+* <http://tasteless.eu/2014/01/gits-2014-lugkist-trivia-150>
 * <https://systemoverlord.com/blog/2014/01/19/ghost-in-the-shellcode-2014-lugkist/>
 * [Chinese](http://ddaa.logdown.com/posts/176382-gits-2014-trivia-150-lugkist)

--- a/ghost-in-the-shellcode-2014/phpcrypto/README.md
+++ b/ghost-in-the-shellcode-2014/phpcrypto/README.md
@@ -92,4 +92,4 @@ ThisWasAStupidTestKeyThatBecameARealBoy
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/01/gits-2014-phpcrypto-recon-100/>
+* <http://tasteless.eu/2014/01/gits-2014-phpcrypto-recon-100/>

--- a/ghost-in-the-shellcode-2014/rabbit-of-caerbannog/README.md
+++ b/ghost-in-the-shellcode-2014/rabbit-of-caerbannog/README.md
@@ -19,4 +19,4 @@ The flag is `Thy_foe_b31ng_n4ughty_1n_My_s1ght_shall_snuff_it`.
 ## Other write-ups and resources
 
 * <http://balidani.blogspot.com/2014/01/ghost-in-shellcode-2014-pwn-adventure-2.html>
-* <http://tasteless.se/2014/01/gits-2014-rabbit-of-caerbannog-pwn-adventure-75/>
+* <http://tasteless.eu/2014/01/gits-2014-rabbit-of-caerbannog-pwn-adventure-75/>

--- a/ghost-in-the-shellcode-2014/radioactive/README.md
+++ b/ghost-in-the-shellcode-2014/radioactive/README.md
@@ -114,4 +114,4 @@ The flag is `Welcom3ToTheNewAgeItsARevolutionISuppose`.
 ## Other write-ups and resources
 
 * <https://systemoverlord.com/blog/2014/01/19/ghost-in-the-shellcode-2014-radioactive/>
-* <http://tasteless.se/2014/01/gits-2014-radioactive-crypto-250/>
+* <http://tasteless.eu/2014/01/gits-2014-radioactive-crypto-250/>

--- a/ghost-in-the-shellcode-2014/unbearable/README.md
+++ b/ghost-in-the-shellcode-2014/unbearable/README.md
@@ -21,4 +21,4 @@ The flag is `The Drunken Master can bear any trial`.
 * <http://balidani.blogspot.com/2014/01/ghost-in-shellcode-2014-pwn-adventure-2.html>
 * <http://lockboxx.blogspot.com/2014/01/ghost-in-shellcode-2014-ctf-writeup.html>
 * <http://quangntenemy.blogspot.com/2014/01/ghost-in-shellcode-2014.html>
-* <http://tasteless.se/2014/01/gits-2014-unbearable-pwn-adventure-75>
+* <http://tasteless.eu/2014/01/gits-2014-unbearable-pwn-adventure-75>

--- a/hack-lu-ctf-2014/at-gunpoint/README.md
+++ b/hack-lu-ctf-2014/at-gunpoint/README.md
@@ -28,6 +28,6 @@ It’s a little hard to read, but the flag is `tkCXDJheQDNRN`.
 
 ## Other write-ups and resources
 
-* [Write-up by tasteless](http://tasteless.se/2014/10/hack-lu-ctf-2014-at-gunpoint/)
+* [Write-up by tasteless](http://tasteless.eu/2014/10/hack-lu-ctf-2014-at-gunpoint/)
 * [Write-up by @bernardomr](http://w00tsec.blogspot.com/2014/10/hacklu-2014-ctf-write-up-at-gunpoint.html)
 * <http://radare.today/solving-at-gunpoint-from-hack-lu-2014-with-radare2/>

--- a/hack-lu-ctf-2014/callgate/README.md
+++ b/hack-lu-ctf-2014/callgate/README.md
@@ -20,5 +20,5 @@
 ## Other write-ups and resources
 
 * [Exploit in Python by @TheJH](thejh_exploit.py)
-* [Write-up by tasteless](http://tasteless.se/2014/10/hack-lu-ctf-2014-callgate/)
+* [Write-up by tasteless](http://tasteless.eu/2014/10/hack-lu-ctf-2014-callgate/)
 * <https://rzhou.org/~ricky/hacklu2014/callgate/>

--- a/hack-lu-ctf-2014/douchemac/README.md
+++ b/hack-lu-ctf-2014/douchemac/README.md
@@ -15,5 +15,5 @@
 
 ## Other write-ups and resources
 
-* [Write-up by tasteless](http://tasteless.se/2014/10/hack-lu-ctf-2014-douchemac/)
+* [Write-up by tasteless](http://tasteless.eu/2014/10/hack-lu-ctf-2014-douchemac/)
 * [Write-up by captchaflag](http://www.captchaflag.com/blog/2014/10/24/hack-dot-lu-2014-douchemac/)

--- a/hack-lu-ctf-2014/peace-pipe/README.md
+++ b/hack-lu-ctf-2014/peace-pipe/README.md
@@ -17,4 +17,4 @@
 
 ## Other write-ups and resources
 
-* [Write-up by tasteless](http://tasteless.se/2014/10/hack-lu-ctf-2014-peace-pipe/)
+* [Write-up by tasteless](http://tasteless.eu/2014/10/hack-lu-ctf-2014-peace-pipe/)

--- a/hitcon-ctf-2014/polyglot/README.md
+++ b/hitcon-ctf-2014/polyglot/README.md
@@ -160,7 +160,7 @@ p("cat flag");
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/08/hitcon2014-polyglot-crazy500/>
+* <http://tasteless.eu/2014/08/hitcon2014-polyglot-crazy500/>
 * <http://www.hxp.io/blog/7/HITCON+CTF+2014%3A+crazy500+%22polyglot%22>
 * <http://v0ids3curity.blogspot.in/2014/08/hitcon-ctf-2014-polyglot-crazy-500.html>
 * <https://rzhou.org/~ricky/hitcon2014/polyglot/>

--- a/hitcon-ctf-2014/sha1lcode/README.md
+++ b/hitcon-ctf-2014/sha1lcode/README.md
@@ -19,7 +19,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/08/hitcon2014-sha1lcode-shellcode300/>
+* <http://tasteless.eu/2014/08/hitcon2014-sha1lcode-shellcode300/>
 * <http://acez.re/ctf-writeup-hitcon-ctf-2014-callme-rsbo-ty-sh41lcode/>
 * <http://www.idabook.com/ctf/sha1lcode_writeup.txt>
 * <http://blog.0x80.org/hitcon-writeup-shellcode/>

--- a/olympic-ctf-2014/elf-quest-2/README.md
+++ b/olympic-ctf-2014/elf-quest-2/README.md
@@ -21,5 +21,5 @@ The flag is `CTF{bf7475cb1733885d35b60e13bc2d7b8f}`.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/02/olympic-ctf-sochi-2014-elf-quest-2-writeup/>
+* <http://tasteless.eu/2014/02/olympic-ctf-sochi-2014-elf-quest-2-writeup/>
 * <http://penthackon.wechall.net/ctf_writeups/Olympic%20CTF%202014/ElfQuest2.htm>

--- a/olympic-ctf-2014/rpc/README.md
+++ b/olympic-ctf-2014/rpc/README.md
@@ -18,7 +18,7 @@ The flag is `CTF{b15ffee30a117f418d1cede6faa57778}`.
 ## Other write-ups and resources
 
 * <http://blog.dragonsector.pl/2014/02/olympic-ctf-2014-rpc-400.html>
-* <http://tasteless.se/2014/02/olympic-ctf-sochi-2014-rpc-writeup/>
+* <http://tasteless.eu/2014/02/olympic-ctf-sochi-2014-rpc-writeup/>
 * <http://www.pwntester.com/blog/2014/02/09/olympic-ctf-curling-tasks/#curling400rpc>
 * <http://lokalhost.pl/ctf/olympic2014_rpc.txt>
 * [Chinese](http://blog.orange.tw/2014/02/olympic-ctf-2014-curling-400-write-up.html)

--- a/olympic-ctf-2014/xnginx/README.md
+++ b/olympic-ctf-2014/xnginx/README.md
@@ -17,7 +17,7 @@ The flag is `CTF{6e75d02b8e8329bb4b45c7dabd2e1da2}`.
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/02/olympic-ctf-sochi-2014-xnginx-writeup/>
+* <http://tasteless.eu/2014/02/olympic-ctf-sochi-2014-xnginx-writeup/>
 * <http://gebl.ctf.ir/2014/02/olympic-ctf-2014-web200/>
 * Documentation for [the `X-Accel-Redirect` header](http://wiki.nginx.org/X-accel#X-Accel-Redirect)
 * [French](http://kmkz-web-blog.blogspot.jp/2014/02/write-up-xnginx-curling-200-olympic-ctf.html)

--- a/phdays-iv-quals/lostandfound/README.md
+++ b/phdays-iv-quals/lostandfound/README.md
@@ -18,5 +18,5 @@ The flags are:
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/01/phd-ctf-quals-2014-lost-and-found-part-2/>
+* <http://tasteless.eu/2014/01/phd-ctf-quals-2014-lost-and-found-part-2/>
 * <http://h0n3yp0t.ru/?p=252>

--- a/plaid-ctf-2014/reeekeeeeee/README.md
+++ b/plaid-ctf-2014/reeekeeeeee/README.md
@@ -12,7 +12,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/04/plaidctf-2014-reeekeeeeee-writeup/>
+* <http://tasteless.eu/2014/04/plaidctf-2014-reeekeeeeee-writeup/>
 * [Source code for this challenge, released after the CTF](https://github.com/pwning/plaidctf2014/tree/master/web/reekee)
 * <https://github.com/hackerclub/writeups/blob/master/plaidctf-2014/reeekeeeeee/WRITEUP-pipecork.md>
 * <http://security.cs.pub.ro/hexcellents/wiki/writeups/pctf2014_reekee>

--- a/plaid-ctf-2014/whatscat/README.md
+++ b/plaid-ctf-2014/whatscat/README.md
@@ -54,7 +54,7 @@ The flag is `20billion_d0llar_1d3a`.
 ## Other write-ups and resources
 
 * [Write-up by Alexey Kaminsky](http://akaminsky.net/plaidctf-quals-2014-web-300-whatscat/)
-* [Write-up by Tasteless](http://tasteless.se/2014/04/plaidctf-2014-whatscat-writeup/)
+* [Write-up by Tasteless](http://tasteless.eu/2014/04/plaidctf-2014-whatscat-writeup/)
 * [Write-up by Ron Bowes](https://blog.skullsecurity.org/2014/plaidctf-writeup-for-web-300-whatscat-sql-injection-via-dns)
 * [Python solution that figures out the flag character by character, by @ngocdh](https://gist.github.com/anonymous/f4e884a234ba5d3c9d37)
 * [Custom DNS server to perform SQL injection through rDNS records, by @phiber](https://gist.github.com/anonymous/ea292c8dc60a2d8fba50)

--- a/ructf-2014-quals/admin-200/README.md
+++ b/ructf-2014-quals/admin-200/README.md
@@ -5,7 +5,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-for200-and-admin200-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-for200-and-admin200-writeup/>
 * <http://h34dump.com/2014/03/ructf-quals-2014-admin-200/>
 * <http://lights-out-ctf.ghost.io/ructf-2014-quals-admin-200-troubleshooting/>
 * <https://hackucf.org/blog/admin-200/>

--- a/ructf-2014-quals/forensics-200/README.md
+++ b/ructf-2014-quals/forensics-200/README.md
@@ -4,6 +4,6 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-for200-and-admin200-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-for200-and-admin200-writeup/>
 * <http://h34dump.com/2014/03/ructf-quals-2014-forensics-200/>
 * [Russian](http://akaminsky.net/ructf-2014-forensics-200-nosql/)

--- a/ructf-2014-quals/recon-300/README.md
+++ b/ructf-2014-quals/recon-300/README.md
@@ -11,7 +11,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-vuln100-and-recon300-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-vuln100-and-recon300-writeup/>
 * <http://h34dump.com/2014/03/933/>
 * <http://onthesystemsoftheworld.blogspot.in/2014/03/ructf-2014-qualifiers-recon-100300400.html>
 * <https://ctfcrew.org/writeup/46>

--- a/ructf-2014-quals/vuln-100/README.md
+++ b/ructf-2014-quals/vuln-100/README.md
@@ -9,7 +9,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-vuln100-and-recon300-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-vuln100-and-recon300-writeup/>
 * <http://h34dump.com/2014/03/ructf-quals-2014-vuln-100/>
 * <http://blog.0xdeffbeef.com/2014/03/ructf-quals-2014-guess-flag-vuln-100.html>
 * <https://ctfcrew.org/writeup/45>

--- a/ructf-2014-quals/web-100/README.md
+++ b/ructf-2014-quals/web-100/README.md
@@ -8,6 +8,6 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-web100-and-web200-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-web100-and-web200-writeup/>
 * <http://nullify-ctf.blogspot.in/2014/03/ructf-quals-2014-web-100-php.html>
 * <http://www.suslopas.pw/2014/03/ructf-web-100-php.html>

--- a/ructf-2014-quals/web-200/README.md
+++ b/ructf-2014-quals/web-200/README.md
@@ -8,7 +8,7 @@
 
 ## Other write-ups and resources
 
-* <http://tasteless.se/2014/03/ructf-quals-2014-web100-and-web200-writeup/>
+* <http://tasteless.eu/2014/03/ructf-quals-2014-web100-and-web200-writeup/>
 * <https://hackucf.org/blog/wp-content/uploads/RuCTF-2014_Web200_Knightsec.pdf>, PDF
 * <https://ctfcrew.org/writeup/48>
 * [Japanese](http://d.hatena.ne.jp/kusano_k/20140310)


### PR DESCRIPTION
We moved our website from tasteless.se to tasteless.eu.
This commit fixes all the links to point to the writeups.